### PR TITLE
Update init.lua to allow dynamic ss3d folder relocation

### DIFF
--- a/ss3d/init.lua
+++ b/ss3d/init.lua
@@ -19,6 +19,6 @@ S:::::::::::::::SS S:::::::::::::::SS 3:::::::::::::::33 D::::::::::::DDD
 
 --]]
 
-cpml = require "ss3d/cpml"
-ObjReader = require "ss3d/reader"
-return require "ss3d/engine"
+cpml = require (... .. ".cpml")
+ObjReader = require (... .. ".reader")
+return require (... .. ".engine")


### PR DESCRIPTION
Added relocatability of the ss3d (main library) folder with regard to the main.lua file. This is useful when moving the library into a differently named folder like 'lib' and you want the 'require' to work.