### PR TITLE
Add UV flip options when loading *.obj files

### DIFF
--- a/g3d/model.lua
+++ b/g3d/model.lua
@@ -29,13 +29,13 @@ model.shader = g3d.shader
 -- this returns a new instance of the model class
 -- a model must be given a .obj file or equivalent lua table, and a texture
 -- translation, rotation, and scale are all 3d vectors and are all optional
-local function newModel(verts, texture, translation, rotation, scale)
+local function newModel(verts, texture, translation, rotation, scale, flipU, flipV)
     local self = setmetatable({}, model)
 
     -- if verts is a string, use it as a path to a .obj file
     -- otherwise verts is a table, use it as a model defintion
     if type(verts) == "string" then
-        verts = loadObjFile(verts)
+        verts = loadObjFile(verts, flipU, flipV)
     end
     assert(verts and type(verts) == "table", "Invalid vertices given to newModel")
 

--- a/g3d/objloader.lua
+++ b/g3d/objloader.lua
@@ -8,7 +8,7 @@
 
 -- give path of file
 -- returns a lua table representation
-return function (path)
+return function (path, flipU, flipV)
     local positions, faces, uvs, normals, model = {}, {}, {}, {}, {}
 
     -- go line by line through the file
@@ -28,8 +28,14 @@ return function (path)
             table.insert(positions, {tonumber(words[2]), tonumber(words[3]), tonumber(words[4])})
         elseif firstWord == "vt" then
             -- if the first word in this line is a "vt", then this defines a texture coordinate
-
-            table.insert(uvs, {tonumber(words[2]), tonumber(words[3])})
+			
+			-- Blender 2.9+ V axis points UP, whereas LÖVE's Y axis points DOWN
+			-- Not sure if any other software has U axis inverted, but why not add this just in case?
+			local U, V = tonumber(words[2]), tonumber(words[3])			
+			if flipU then U = 1 - U end
+			if flipV then V = 1 - V end
+			
+            table.insert(uvs, {U,V})
         elseif firstWord == "vn" then
             -- if the first word in this line is a "vn", then this defines a vertex normal
 


### PR DESCRIPTION
OBJ loader assumes that UV map goes from left to right for U and from bottom to top for V.
I've spent countless hours trying to figure out why my textures were all flipped around for no particular reason only to realize that `UV Vertex` lists top-right corner as {0.999, 0.999} (I'm using snapping to mid-pixel).

Not sure if this is the reason those canvas-enabled textures seem to be flipped (thus requiring a separate check in vertex shader).

