### PR TITLE
Prevent vectors.normalize from returning NaN on vectors with zero length

### DIFF
--- a/g3d/vectors.lua
+++ b/g3d/vectors.lua
@@ -32,7 +32,11 @@ end
 
 function vectors.normalize(x,y,z)
     local mag = math.sqrt(x^2 + y^2 + z^2)
-    return x/mag, y/mag, z/mag
+    if mag ~= 0 then
+        return x/mag, y/mag, z/mag
+    else
+        return 0, 0, 0
+    end
 end
 
 function vectors.magnitude(x,y,z)


### PR DESCRIPTION
Have vectors.normalize return 0,0,0 if the vector length is 0