### PR TITLE
Update objloader to accept non-triangulated faces and fix shaderpath problem

### DIFF
--- a/g3d/init.lua
+++ b/g3d/init.lua
@@ -42,7 +42,7 @@ g3d = {
         SOFTWARE.
     ]],
     path = ...,
-    shaderpath = ... .. "/g3d.vert",
+    shaderpath = (...):gsub("%.", "/") .. "/g3d.vert",
 }
 
 -- the shader is what does the heavy lifting, displaying 3D meshes on your 2D monitor

--- a/g3d/objloader.lua
+++ b/g3d/objloader.lua
@@ -39,19 +39,18 @@ return function (path, uFlip, vFlip)
             table.insert(uvs, {u, v})
         elseif firstWord == "vn" then
             -- if the first word in this line is a "vn", then this defines a vertex normal
-
             table.insert(normals, {tonumber(words[2]), tonumber(words[3]), tonumber(words[4])})
         elseif firstWord == "f" then
+
             -- if the first word in this line is a "f", then this is a face
             -- a face takes three point definitions
             -- the arguments a point definition takes are vertex, vertex texture, vertex normal in that order
 
-            assert(#words == 4, ("Faces in level %s must be triangulated before they can be loaded!"):format(path))
-
-            for i=2, #words do
+            local vertices = {}
+            for i = 2, #words do
                 local v, vt, vn = words[i]:match "(%d*)/(%d*)/(%d*)"
                 v, vt, vn = tonumber(v), tonumber(vt), tonumber(vn)
-                local vert = {
+                table.insert(vertices, {
                     v and positions[v][1] or 0,
                     v and positions[v][2] or 0,
                     v and positions[v][3] or 0,
@@ -60,9 +59,26 @@ return function (path, uFlip, vFlip)
                     vn and normals[vn][1] or 0,
                     vn and normals[vn][2] or 0,
                     vn and normals[vn][3] or 0,
-                }
-                table.insert(result, vert)
+                })
             end
+
+            -- triangulate the face if it's not already a triangle
+            if #vertices > 3 then
+                -- choose a central vertex
+                local centralVertex = vertices[1]
+
+                -- connect the central vertex to each of the other vertices to create triangles
+                for i = 2, #vertices - 1 do
+                    table.insert(result, centralVertex)
+                    table.insert(result, vertices[i])
+                    table.insert(result, vertices[i + 1])
+                end
+            else
+                for i = 1, #vertices do
+                    table.insert(result, vertices[i])
+                end
+            end
+
         end
     end
 


### PR DESCRIPTION
**I updated the `objloader.lua` script to accept non-triangulated OBJ models.**

And I also changed the way the path to the shader was built. Why ?

Wanting to import g3d like this `local g3d = require("lib.g3d")` I got this error:
`Error: lib/g3d/init.lua:49: Could not open file lib.g3d/g3d.vert. Does not exist.`

So I corrected it by replacing `shaderpath = ... .. "/g3d.vert"` by `shaderpath = (...):gsub("%.", "/") .. "/g3d.vert"`

I would like to specify that this modification does not prevent importing the module like this `require("g3d")` or like this `require("lib/g3d")`.